### PR TITLE
Improve lubTypeReps documentation

### DIFF
--- a/Frames.cabal
+++ b/Frames.cabal
@@ -50,13 +50,14 @@ library
                        OverloadedStrings
   build-depends:       base >=4.8 && <4.10,
                        ghc-prim >=0.3 && <0.6,
+                       pipes >= 4.1 && < 5,
                        primitive >= 0.6 && < 0.7,
-                       text >= 1.1.1.0,
+                       readable >= 0.3.1,
                        template-haskell,
+                       text >= 1.1.1.0,
+                       time >= 1.5.0.1,
                        transformers,
                        vector,
-                       readable >= 0.3.1,
-                       pipes >= 4.1 && < 5,
                        vinyl >= 0.5 && < 0.6
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Frames/ColumnTypeable.hs
+++ b/src/Frames/ColumnTypeable.hs
@@ -4,6 +4,8 @@ import Control.Monad (MonadPlus)
 import Data.Readable (Readable(fromText))
 import qualified Data.Text as T
 import Language.Haskell.TH
+import Data.Time
+import Data.Time (ZonedTime(..))
 
 data Parsed a = Possibly a | Definitely a deriving (Eq, Ord, Show)
 
@@ -41,6 +43,12 @@ instance Parseable Double where
   -- Some CSV's export Doubles in a format like '1,000.00', filtering out commas lets us parse those sucessfully
   parse = fmap Definitely . fromText . T.filter (/= ',')
 instance Parseable T.Text where
+instance Parseable ZonedTime where
+  parse txt = do
+    fmap Definitely (parseTimeM True defaultTimeLocale "%F %T" (T.unpack txt ))
+    -- case (parseTimeM True defaultTimeLocale "%F %T" (T.unpack txt ):: Maybe ZonedTime) of
+    --   Just zt -> pure $ Definitely zt
+    --   Nothing -> error "Hm. not sure what to do here"
 
 -- | This class relates a universe of possible column types to Haskell
 -- types, and provides a mechanism to infer which type best represents

--- a/src/Frames/ColumnUniverse.hs
+++ b/src/Frames/ColumnUniverse.hs
@@ -34,6 +34,7 @@ import Frames.RecF (reifyDict)
 import Frames.TypeLevel (LAll)
 import Data.Typeable (TypeRep)
 import Data.Maybe (fromMaybe)
+import Data.Time
 
 -- * TypeRep Helpers
 
@@ -103,10 +104,12 @@ lubTypeReps (Definitely trX) (Definitely trY)
   | trX == trDbl && trY == trInt = Just GT
   | trX == trBool && trY == trInt = Just LT
   | trX == trInt && trY == trBool = Just GT
+  | trX == trZoneTime && trY == trZoneTime = Just GT
   | otherwise = Nothing
   where trInt = typeRep (Proxy :: Proxy Int)
         trDbl = typeRep (Proxy :: Proxy Double)
         trBool = typeRep (Proxy :: Proxy Bool)
+        trZoneTime = typeRep (Proxy :: Proxy ZonedTime)
 
 instance (T.Text ∈ ts) => Monoid (CoRec ColInfo ts) where
   mempty = Col (ColInfo ([t|T.Text|], Possibly mkTyped) :: ColInfo T.Text)
@@ -146,7 +149,7 @@ instance (LAll Parseable ts, LAll Typeable ts, FoldRec ts ts,
 -- * Common Columns
 
 -- | Common column types
-type CommonColumns = [Bool, Int, Double, T.Text]
+type CommonColumns = [ZonedTime, Bool, Int, Double, T.Text]
 
 -- | Define a set of variants that captures all possible column types.
 type ColumnUniverse = CoRec ColInfo

--- a/src/Frames/ColumnUniverse.hs
+++ b/src/Frames/ColumnUniverse.hs
@@ -92,6 +92,16 @@ newtype ColInfo a = ColInfo (Q Type, Parsed (Typed a))
 -- | We use a join semi-lattice on types for representations. The
 -- bottom of the lattice is effectively an error (we have nothing to
 -- represent), @Bool < Int@, @Int < Double@, and @forall n. n <= Text@.
+--
+-- The high-level goal here is that we will pick the "greater" of two
+-- choices in 'bestRep'. A 'Definitely' parse result is preferred over
+-- a 'Possibly' parse result. If we have two distinct 'Possibly' parse
+-- results, we give up. If we have two distinct 'Definitely' parse
+-- results, we are in dangerous waters: all data is parseable at
+-- /both/ types, so which do we default to? The defaulting choices
+-- made here are described in the previous paragraph. If there is no
+-- defaulting rule, we give up (i.e. use 'T.Text' as a
+-- representation).
 lubTypeReps :: Parsed TypeRep -> Parsed TypeRep -> Maybe Ordering
 lubTypeReps (Possibly _) (Definitely _) = Just LT
 lubTypeReps (Definitely _) (Possibly _) = Just GT
@@ -104,12 +114,10 @@ lubTypeReps (Definitely trX) (Definitely trY)
   | trX == trDbl && trY == trInt = Just GT
   | trX == trBool && trY == trInt = Just LT
   | trX == trInt && trY == trBool = Just GT
-  | trX == trZoneTime && trY == trZoneTime = Just GT
   | otherwise = Nothing
   where trInt = typeRep (Proxy :: Proxy Int)
         trDbl = typeRep (Proxy :: Proxy Double)
         trBool = typeRep (Proxy :: Proxy Bool)
-        trZoneTime = typeRep (Proxy :: Proxy ZonedTime)
 
 instance (T.Text ∈ ts) => Monoid (CoRec ColInfo ts) where
   mempty = Col (ColInfo ([t|T.Text|], Possibly mkTyped) :: ColInfo T.Text)


### PR DESCRIPTION
The comparison for TimeZones in `lubTypes` overlapped the existing equality case, so I removed it.
